### PR TITLE
In ruby 1.9 ftools is deprecated. Use fileutils instead.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 #!/usr/bin/ruby
 # -*- coding: UTF-8 -*-
 
-require 'ftools'
+require 'fileutils'
 require 'erb'
 require 'rubygems'
 
@@ -39,7 +39,7 @@ rule( /\.json$/ => [
 ]) do |t|
   abs_source = File.expand_path(t.source)
   abs_name   = File.expand_path(t.name)
-  File.makedirs File.dirname abs_name
+  FileUtils.makedirs File.dirname abs_name
   puts "parse #{abs_source}"
   sh "(cd jsttyplay; rm -f #{abs_name}; perl preprocess.pl --size 80x25 #{abs_source} #{abs_name})"
 end


### PR DESCRIPTION
REF:http://redmine.ruby-lang.org/issues/1401
